### PR TITLE
[Bug Fix] : afu_sim_setup is using source files from PD meant for Synthesis instead of Simulation, which does not work for encrypted IP.  IP files listed in sources.txt skipped

### DIFF
--- a/ase/scripts/generate_ase_environment.py
+++ b/ase/scripts/generate_ase_environment.py
@@ -393,39 +393,41 @@ def config_qsys_sources(filelist, vlog_srcs, vhdl_srcs):
     if (not qsys_srcs):
         return dict()
 
-    # First step: copy the trees holding Qsys sources to a temporary tree
+    # First step: copy the trees holding Qsys, IP sources to a temporary tree
     # inside the simulator environment.  We do this to avoid polluting the
     # source tree with Qsys-generated files.
-    copied_qsys_dirs = dict()
+    copied_qsys_ip_dirs = dict()
     copied_tcl_dirs = dict()
     tgt_idx = 0
     os.mkdir('qsys_sim')
-    qsys_srcs_copy = []
+    qsys_ip_srcs_copy = []
     tcl_srcs_copy = []
-    for q in qsys_srcs:
+    for q in srcs:
+        if(len(q) == 0):
+            continue
         src_dir = os.path.dirname(q)
         base_filelist = os.path.dirname(filelist)
         paths = [src_dir, base_filelist]
         common_prefix = os.path.commonprefix(paths)
+        src_dir_base = os.path.basename(src_dir)
+        b = remove_prefix(src_dir, common_prefix)
+        b = b.strip("/")
+        tgt_dir = os.path.join('qsys_sim', b)
         # Has the source been copied already? Multiple Qsys files in the same
         # directory are copied together.
-        if (src_dir not in copied_qsys_dirs):
-            src_dir_base = os.path.basename(src_dir)
-            b = remove_prefix(src_dir, common_prefix)
-            b = b.strip("/")
-            tgt_dir = os.path.join('qsys_sim', b)
-            copied_qsys_dirs[src_dir] = tgt_dir
+        if (src_dir not in copied_qsys_ip_dirs):
+            copied_qsys_ip_dirs[src_dir] = tgt_dir
             print("Preparing {0}:".format(q))
             print("  Copying {0} to {1}...".format(src_dir, tgt_dir))
             try:
-                shutil.copytree(src_dir, tgt_dir, symlinks=False, ignore=None)
+                shutil.copytree(src_dir, tgt_dir, symlinks=False, ignore=None, dirs_exist_ok=True)
             except Exception as e:
                 errorExit("Failed to copy tree {0} to "
                           "{1}: Exception {2}".
                           format(src_dir, tgt_dir, e))
 
         # Point to the copy
-        qsys_srcs_copy.append(tgt_dir + q[len(src_dir):])
+        qsys_ip_srcs_copy.append(tgt_dir + q[len(src_dir):])
 
     for t in tcl_srcs:
         src_dir = os.path.dirname(t)
@@ -456,13 +458,13 @@ def config_qsys_sources(filelist, vlog_srcs, vhdl_srcs):
     ip_dirs_copy = []
     for d in ip_dirs:
         match = None
-        for src in copied_qsys_dirs:
+        for src in copied_qsys_ip_dirs:
             if (src == d[:len(src)]):
                 match = src
                 break
         if match:
             # Replace the prefix (source tree) with the copied prefix
-            ip_dirs_copy.append(copied_qsys_dirs[match] + d[len(match):])
+            ip_dirs_copy.append(copied_qsys_ip_dirs[match] + d[len(match):])
         else:
             # Didn't find a match.  Use the original.
             ip_dirs_copy.append(d)
@@ -473,9 +475,9 @@ def config_qsys_sources(filelist, vlog_srcs, vhdl_srcs):
     # We use synthesis mode instead of simulation because the generated
     # simulation control isn't needed for ASE and because some Qsys
     # projects are set up only for synthesis.
-    cmd.append('--synthesis=VERILOG')
+    cmd.append('--simulation=VERILOG')
 
-    for q in qsys_srcs_copy:
+    for q in qsys_ip_srcs_copy:
         cmd.append(q)
         print("\nBuilding " + q)
         try:
@@ -505,7 +507,7 @@ def config_qsys_sources(filelist, vlog_srcs, vhdl_srcs):
         for d in ip_dirs_copy:
             for dir, subdirs, files in os.walk(d):
                 for fn in sorted(files, key=sort_key_qsys_files):
-                    if ((os.path.basename(dir) == 'synth') and
+                    if ((os.path.basename(dir) == 'sim') and
                             (fn.endswith('.v') or fn.endswith('.sv') or
                              fn.endswith('.vhd') or fn.endswith('.hex'))):
                         full_path = os.path.join(dir, fn)


### PR DESCRIPTION

*PR Title should start with one of the following tags: [Fix]/[Feature]/[Style]/[Update]*

*[Fix]- Bug Fix*

*[Feature]- for new feature*

*[Style]- Grammar or branding fix*

*[Update]-For an update to an existing feature*

------------- *Keep everything below this line* -------------------------

### Description
*Describe the issue, update, change or fix and **why***
Issue - afu sim was not generating simulation collateral for ip files listed in sources.txt

Update - Updated generate_ase_environment.py. Script was using qsys generate with synthesis argument , updated it to simulation . Script had bug and was skipping over .ip files listed in sources.txt. Fixed code to not skip over .ip files and generate simulations collateral for them using qsys generate -sim 


### Collateral (docs, reports, design examples, case IDs):
HSD 22018472968


- [ ] Document Update Required? (Specify FIM/AFU/Scripts) 

### Tests added:

### Tests run:
Tested it on P4 project Ryan is working on, where he saw this issue.
He confirmed he no longer sees the issue when using fix locally.
